### PR TITLE
Removed ClusterIndex from FUObjectItem class

### DIFF
--- a/PlayerUnknownsBattlegrounds.vcxproj
+++ b/PlayerUnknownsBattlegrounds.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{C9338E0E-7CCC-4256-AE59-B1B1CEF6CCE5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>PlayerUnknownsBattlegrounds</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
     <ProjectName>PlayerunknownsBattlegrounds</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/Target/PUBG/Generator.cpp
+++ b/Target/PUBG/Generator.cpp
@@ -196,7 +196,7 @@ public:
 	}
 	virtual std::string GetGameVersion() const override
 	{
-		return "2.5.39.19";
+		return "2.6.23";
 	}
 
 	virtual std::string GetNamespaceName() const override
@@ -605,7 +605,7 @@ struct FText
 
 struct FScriptDelegate
 {
-	char UnknownData[20];
+	char UnknownData[14];
 };
 
 struct FScriptMulticastDelegate

--- a/Target/PUBG/Generator.cpp
+++ b/Target/PUBG/Generator.cpp
@@ -229,7 +229,6 @@ class FUObjectItem
 public:
 	UObject* Object;
 	int32_t Flags;
-	int32_t ClusterIndex;
 	int32_t SerialNumber;
 
 	enum class EInternalObjectFlags : int32_t

--- a/Target/PUBG/Generator.cpp
+++ b/Target/PUBG/Generator.cpp
@@ -196,7 +196,7 @@ public:
 	}
 	virtual std::string GetGameVersion() const override
 	{
-		return "2.4.24";
+		return "2.5.39.19";
 	}
 
 	virtual std::string GetNamespaceName() const override


### PR DESCRIPTION
Looks like PUBG is using an older UE4 version, it has no ClusterIndex yet.
EDIT:
Changed size of UnknownData in FScriptDelegate to 14.
Updated GetGameVersion to current version.
Updated WindowsTargetPlatformVersion to latest Windows SDK.
